### PR TITLE
add support for sub documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ let options = {
   noDiffSaveOnMethods: ['delete'], // If a method is in this list, it saves history even if there is no diff.
   noEventSave: true, // If false save only when __history property is passed
   modelName: '__histories', // Name of the collection for the histories
+  embeddedDocument: false, // Is this a sub document
+  embeddedModelName: '', // Name of model if used with embedded document
   mongoose: mongoose // A mongoose instance
 };
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "coveralls": "^3.0.2",
     "expect": "^24.0.0",
     "mongoose": "^5.4.9",
-    "nyc": "^13.1.0",
+    "nyc": "^14.1.0",
     "remark-cli": "^6.0.1",
     "remark-toc": "^5.1.1"
   },


### PR DESCRIPTION
Adds support for embedded/sub documents. Because sub docs do not have a modelName, the config is updated to accept whether this is embedded and the model name to use. A convenience method for getting the model name has also been added to get the configured name if embedded or return the default provided.