### PR TITLE
Support for other than ObjectID as binary index 

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,8 @@ let historyPlugin = (options = {}) => {
 
   let mongoose = pluginOptions.mongoose;
 
-  const collectionIdType = options.collectionIdType || mongoose.Schema.Types.ObjectId
-  
+  const collectionIdType = options.collectionIdType || mongoose.Schema.Types.ObjectId;
+
   let Schema = new mongoose.Schema(
     {
       collectionName: String,


### PR DESCRIPTION
Fixing to allow the use other than ObjectID (i.e. UUID) as the collection id.