### PR TITLE
fix: update getPreviousVersion logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ small
     return small.save();
   })
   .then((small) => {
+    // Create another history version
+    small.name = 'Smallest tank';
+
+    // History property is optional by default
+    small.__history = {
+      event: 'updated',
+      user: undefined,
+      reason: undefined,
+      data: undefined,
+      type: undefined,
+      method: 'updateTank'
+    };
+
+    return small.save();
+  })
+  .then((small) => {
     // All options are optional
     let query = {
       find: {}, // Must be an object
@@ -144,6 +160,12 @@ small
     small.getDiffs(query).then(console.log);
     /*
     [ 
+      { 
+        version: '2.0.0',
+        diff: { name: ['Small tank', 'Smallest tank'] },
+        event: 'updated',
+        method: 'updateTank',
+        timestamp: 2019-08-24T12:04:15.253Z },
       { 
         version: '1.0.0',
         diff: { name: [ 'Small tank' ] },
@@ -180,6 +202,13 @@ small
     small.getVersions(query).then(console.log);
     /*
     [ 
+      {
+        version: '2.0.0',
+        event: 'updated',
+        method: 'updateTank',
+        timestamp: expect.any(Date),
+        object: { name: 'Smallest tank' }
+      },
       { 
         version: '1.0.0',
         event: 'updated',

--- a/index.js
+++ b/index.js
@@ -120,10 +120,10 @@ let historyPlugin = (options = {}) => {
   };
 
   let getPreviousVersion = async (document) => {
-    // get the older version from the history collection
+    // get the oldest version from the history collection
     let versions = await document.getVersions();
-    return versions[0] ?
-      versions[0].object :
+    return versions[versions.length - 1] ?
+      versions[versions.length - 1].object :
       {};
   };
 
@@ -166,7 +166,7 @@ let historyPlugin = (options = {}) => {
     return object;
   };
 
-  let getDiff = ({prev, current, document, forceSave}) => {
+  let getDiff = ({ prev, current, document, forceSave }) => {
     let diff = jdf.diff(prev, current);
 
     let saveWithoutDiff = false;
@@ -186,7 +186,7 @@ let historyPlugin = (options = {}) => {
     };
   };
 
-  let saveHistory = async ({document, diff}) => {
+  let saveHistory = async ({ document, diff }) => {
     let lastHistory = await Model.findOne({
       collectionName: getModelName(document.constructor.modelName),
       collectionId: document._id
@@ -206,8 +206,8 @@ let historyPlugin = (options = {}) => {
         pluginOptions.userFieldName
       ];
       obj[pluginOptions.accountFieldName] =
-      document[pluginOptions.accountFieldName] ||
-      document.__history[pluginOptions.accountFieldName];
+        document[pluginOptions.accountFieldName] ||
+        document.__history[pluginOptions.accountFieldName];
       obj.reason = document.__history.reason;
       obj.data = document.__history.data;
       obj[pluginOptions.methodFieldName] = document.__history[
@@ -219,9 +219,9 @@ let historyPlugin = (options = {}) => {
 
     if (lastHistory) {
       let type =
-      document.__history && document.__history.type
-        ? document.__history.type
-        : 'major';
+        document.__history && document.__history.type
+          ? document.__history.type
+          : 'major';
 
       version = semver.inc(lastHistory.version, type);
     }
@@ -264,7 +264,7 @@ let historyPlugin = (options = {}) => {
               await repopulate(currentDocument, populatedFields);
             }
 
-            let {diff, saveWithoutDiff} = getDiff({
+            let { diff, saveWithoutDiff } = getDiff({
               current: currentObject,
               prev: previousObject,
               document: currentDocument,
@@ -272,7 +272,7 @@ let historyPlugin = (options = {}) => {
             });
 
             if (diff || pluginOptions.noDiffSave || saveWithoutDiff) {
-              await saveHistory({document: currentDocument, diff});
+              await saveHistory({ document: currentDocument, diff });
             }
 
             return next();
@@ -348,7 +348,7 @@ let historyPlugin = (options = {}) => {
       histories.map((item) => {
         if (
           semver.lt(item.version, version2get) ||
-            item.version === version2get
+          item.version === version2get
         ) {
           version = jdf.patch(version, item.diff);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-history-plugin",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Mongoose plugin that saves history in JsonPatch format and SemVer format",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updated getPreviousVersion method logic to grab the last item in the in the versions array.
Previously it was always getting version "0.0.0" which was leading to adverse behavior in diff.

BREAKING CHANGE: Saved diff for histories with more than 2 versions could result in different diff
than previous behavior.